### PR TITLE
Impl compile_while_statement

### DIFF
--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -216,7 +216,15 @@ impl CompilationEngine for XmlCompilationEngine {
         self.write_key_word(vec![KeyWord::Let], writer)?;
         // varName
         self.write_identifier(writer)?;
-        // TODO: (’[’ expression ’]’)?
+        // (’[’ expression ’]’)?
+        if self.tokenizer.peek()?.value() == "[" {
+            // ’[’
+            self.write_symbol(writer)?;
+            // expression
+            self.compile_expression(writer)?;
+            // ’]’
+            self.write_symbol(writer)?;
+        }
         // ’=’
         self.write_symbol(writer)?;
         // expression

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -390,7 +390,7 @@ impl XmlCompilationEngine {
     fn write_integer_constant(&mut self, writer: &mut impl Write) -> Result<()> {
         self.tokenizer.advance()?;
         match self.tokenizer.token_type()? {
-            TokenType::StringConst => writeln!(
+            TokenType::IntConst => writeln!(
                 writer,
                 "<integerConstant> {} </integerConstant>",
                 self.tokenizer.int_val()?

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -194,7 +194,17 @@ impl CompilationEngine for XmlCompilationEngine {
 
     /// statement = letStatement | ifStatement | whileStatement | doStatement | returnStatement
     fn compile_statement(&mut self, writer: &mut impl Write) -> Result<()> {
-        self.compile_let_statement(writer)?;
+        match self.tokenizer.token_type()? {
+            TokenType::Keyword => match self.tokenizer.key_word()? {
+                KeyWord::Let => self.compile_let_statement(writer)?,
+                KeyWord::If => todo!("ifStatement"),
+                KeyWord::While => todo!("whileStatement"),
+                KeyWord::Do => todo!("doStatement"),
+                KeyWord::Return => todo!("returnStatement"),
+                _ => {}
+            },
+            _ => {}
+        }
         Ok(())
     }
 

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -16,6 +16,7 @@ trait CompilationEngine {
     fn compile_statements(&mut self, writer: &mut impl Write) -> Result<()>;
     fn compile_statement(&mut self, writer: &mut impl Write) -> Result<()>;
     fn compile_let_statement(&mut self, writer: &mut impl Write) -> Result<()>;
+    fn compile_while_statement(&mut self, writer: &mut impl Write) -> Result<()>;
     fn compile_expression(&mut self, writer: &mut impl Write) -> Result<()>;
     fn compile_term(&mut self, writer: &mut impl Write) -> Result<()>;
     fn compile_subroutine_call(&mut self, writer: &mut impl Write) -> Result<()>;
@@ -208,15 +209,12 @@ impl CompilationEngine for XmlCompilationEngine {
 
     /// statement = letStatement | ifStatement | whileStatement | doStatement | returnStatement
     fn compile_statement(&mut self, writer: &mut impl Write) -> Result<()> {
-        match self.tokenizer.token_type()? {
-            TokenType::Keyword => match self.tokenizer.key_word()? {
-                KeyWord::Let => self.compile_let_statement(writer)?,
-                KeyWord::If => todo!("ifStatement"),
-                KeyWord::While => todo!("whileStatement"),
-                KeyWord::Do => todo!("doStatement"),
-                KeyWord::Return => todo!("returnStatement"),
-                _ => {}
-            },
+        match KeyWord::from(self.tokenizer.peek()?.value())? {
+            KeyWord::Let => self.compile_let_statement(writer)?,
+            KeyWord::If => todo!("ifStatement"),
+            KeyWord::While => self.compile_while_statement(writer)?,
+            KeyWord::Do => todo!("doStatement"),
+            KeyWord::Return => todo!("returnStatement"),
             _ => {}
         }
         Ok(())
@@ -247,6 +245,29 @@ impl CompilationEngine for XmlCompilationEngine {
         self.write_symbol(writer)?;
         // </letStatement>
         self.write_end_tag("letStatement", writer)?;
+        Ok(())
+    }
+
+    /// whileStatement = ’while’ ’(’ expression ’)’ ’{’ statements ’}’
+    fn compile_while_statement(&mut self, writer: &mut impl Write) -> Result<()> {
+        // <whileStatement>
+        self.write_start_tag("whileStatement", writer)?;
+        // while
+        self.write_key_word(vec![KeyWord::While], writer)?;
+        // ’(’
+        self.write_symbol(writer)?;
+        // expression
+        self.compile_expression(writer)?;
+        // ’)’
+        self.write_symbol(writer)?;
+        // ’{’
+        self.write_symbol(writer)?;
+        // statements
+        self.compile_statements(writer)?;
+        // ’}’
+        self.write_symbol(writer)?;
+        // </whileStatement>
+        self.write_end_tag("whileStatement", writer)?;
         Ok(())
     }
 
@@ -734,6 +755,96 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn can_compile_while_statement() {
+        let expected = "\
+            <whileStatement>\n\
+            <keyword> while </keyword>\n\
+            <symbol> ( </symbol>\n\
+            <expression>\n\
+            <term>\n\
+            <identifier> i </identifier>\n\
+            </term>\n\
+            <symbol> &lt; </symbol>\n\
+            <term>\n\
+            <identifier> length </identifier>\n\
+            </term>\n\
+            </expression>\n\
+            <symbol> ) </symbol>\n\
+            <symbol> { </symbol>\n\
+            <statements>\n\
+            <letStatement>\n\
+            <keyword> let </keyword>\n\
+            <identifier> a </identifier>\n\
+            <symbol> [ </symbol>\n\
+            <expression>\n\
+            <term>\n\
+            <identifier> i </identifier>\n\
+            </term>\n\
+            </expression>\n\
+            <symbol> ] </symbol>\n\
+            <symbol> = </symbol>\n\
+            <expression>\n\
+            <term>\n\
+            <identifier> Keyboard </identifier>\n\
+            <symbol> . </symbol>\n\
+            <identifier> readInt </identifier>\n\
+            <symbol> ( </symbol>\n\
+            <expressionList>\n\
+            <expression>\n\
+            <term>\n\
+            <stringConstant> ENTER THE NEXT NUMBER:  </stringConstant>\n\
+            </term>\n\
+            </expression>\n\
+            </expressionList>\n\
+            <symbol> ) </symbol>\n\
+            </term>\n\
+            </expression>\n\
+            <symbol> ; </symbol>\n\
+            </letStatement>\n\
+            <letStatement>\n\
+            <keyword> let </keyword>\n\
+            <identifier> i </identifier>\n\
+            <symbol> = </symbol>\n\
+            <expression>\n\
+            <term>\n\
+            <identifier> i </identifier>\n\
+            </term>\n\
+            <symbol> + </symbol>\n\
+            <term>\n\
+            <integerConstant> 1 </integerConstant>\n\
+            </term>\n\
+            </expression>\n\
+            <symbol> ; </symbol>\n\
+            </letStatement>\n\
+            </statements>\n\
+            <symbol> } </symbol>\n\
+            </whileStatement>\n"
+            .to_string();
+
+        let mut src_file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(src_file, "while (i < length) {{").unwrap();
+        writeln!(
+            src_file,
+            "let a[i] = Keyboard.readInt(\"ENTER THE NEXT NUMBER: \");"
+        )
+        .unwrap();
+        writeln!(src_file, "let i = i + 1;").unwrap();
+        writeln!(src_file, "}}").unwrap();
+        src_file.seek(SeekFrom::Start(0)).unwrap();
+        let path = src_file.path();
+        let mut output = Vec::<u8>::new();
+
+        let tokenizer = JackTokenizer::new(path).unwrap();
+        let mut engine = XmlCompilationEngine::new(tokenizer);
+
+        let result = engine.compile_while_statement(&mut output);
+        let actual = String::from_utf8(output).unwrap();
+
+        assert_eq!(expected, actual);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -188,7 +188,21 @@ impl CompilationEngine for XmlCompilationEngine {
 
     /// statements = statement*
     fn compile_statements(&mut self, writer: &mut impl Write) -> Result<()> {
-        self.compile_statement(writer)?;
+        // <statements>
+        self.write_start_tag("statements", writer)?;
+        loop {
+            if !KeyWord::exists(self.tokenizer.peek()?.value()) {
+                break;
+            }
+            match KeyWord::from(self.tokenizer.peek()?.value())? {
+                KeyWord::Let | KeyWord::If | KeyWord::While | KeyWord::Do | KeyWord::Return => {
+                    self.compile_statement(writer)?;
+                }
+                _ => break,
+            }
+        }
+        // </statements>
+        self.write_end_tag("statements", writer)?;
         Ok(())
     }
 

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -234,7 +234,17 @@ impl CompilationEngine for XmlCompilationEngine {
         self.write_start_tag("expression", writer)?;
         // term
         self.compile_term(writer)?;
-        // TODO: (op term)*
+        // (op term)*
+        loop {
+            if self.tokenizer.peek()?.is_op() {
+                // op
+                self.write_symbol(writer)?;
+                // term
+                self.compile_term(writer)?;
+            } else {
+                break;
+            }
+        }
         // </expression>
         self.write_end_tag("expression", writer)?;
         Ok(())

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -416,7 +416,7 @@ impl XmlCompilationEngine {
                     _ => "",
                 };
 
-                if symbol == "" {
+                if symbol.is_empty() {
                     writeln!(writer, "<symbol> {} </symbol>", self.tokenizer.symbol())?
                 } else {
                     writeln!(writer, "<symbol> {} </symbol>", symbol)?

--- a/src/compilation/compilation_engine.rs
+++ b/src/compilation/compilation_engine.rs
@@ -356,7 +356,18 @@ impl XmlCompilationEngine {
         self.tokenizer.advance()?;
         match self.tokenizer.token_type()? {
             TokenType::Symbol => {
-                writeln!(writer, "<symbol> {} </symbol>", self.tokenizer.symbol())?
+                let symbol = match self.tokenizer.symbol() {
+                    '<' => "&lt;",
+                    '>' => "&gt;",
+                    '&' => "&amp;",
+                    _ => "",
+                };
+
+                if symbol == "" {
+                    writeln!(writer, "<symbol> {} </symbol>", self.tokenizer.symbol())?
+                } else {
+                    writeln!(writer, "<symbol> {} </symbol>", symbol)?
+                }
             }
             _ => bail!(Error::msg("Illegal token")),
         }

--- a/src/tokenizer/token.rs
+++ b/src/tokenizer/token.rs
@@ -28,4 +28,11 @@ impl Token {
     pub fn value(&self) -> &String {
         &self.value
     }
+
+    pub fn is_op(&self) -> bool {
+        match self.value.as_str() {
+            "+" | "-" | "*" | "/" | "&" | "|" | "<" | ">" | "=" => true,
+            _ => false,
+        }
+    }
 }

--- a/src/tokenizer/token.rs
+++ b/src/tokenizer/token.rs
@@ -30,9 +30,9 @@ impl Token {
     }
 
     pub fn is_op(&self) -> bool {
-        match self.value.as_str() {
-            "+" | "-" | "*" | "/" | "&" | "|" | "<" | ">" | "=" => true,
-            _ => false,
-        }
+        matches!(
+            self.value.as_str(),
+            "+" | "-" | "*" | "/" | "&" | "|" | "<" | ">" | "="
+        )
     }
 }


### PR DESCRIPTION
- feat: separate statement patterns
- feat: impl is_op
- refactor: escape special symbol
- fix: write_integer_constant for intConst
- feat: impl (op term)* in compile_expression
- feat: impl (’[’ expression ’]’)? in compile_let_expression
- feat: impl compile_statements
- feat: impl compile_while_statement
- refactor: using
- refactor: use matches! macro
